### PR TITLE
First read-through for spelling and style

### DIFF
--- a/handlers.lagda
+++ b/handlers.lagda
@@ -416,7 +416,7 @@ manually defining our own predicate on expressions:
   SafeDiv (Val x)       = ⊤
   SafeDiv (Div e1 e2)   = (e2 ⇓ Zero -> ⊥) ∧ SafeDiv e1 ∧ SafeDiv e2
 \end{code}
-We would expect that any expression |e| for which |SafeDiv e| holds,
+We would expect that any expression |e| for which |SafeDiv e| holds
 can be evaluated without encountering a division-by-zero
 error. Indeed, we can prove that |SafeDiv| is a sufficient condition
 for our two notions of evaluation to coincide:


### PR DESCRIPTION
Nog wat openstaande issues:

 - [ ] Is het "a semantics is" (telbaar enkelvoud), "some semantics is" (ontelbaar), "semantics are" (telbaar meervoud)? Volgens Wiktionary is het ontelbaar, maar in het artikel zie ik zowel enkelvoud- als meervoudsvormen.
- [ ] Regel 1052: Using this composition operator, we can show that for \emph{any}
compositional predicate transformer semantics,
  ```Agda
  compositionality1 : (Forall(a b c : Set)) (f1 f2 : a -> Free C R b) (g : b -> Free C R c) ->
    wpCR f1 ⊑ wpCR f2 ->
    wpCR (f1 >=> g) ⊑ wpCR (f2 >=> g)
  ```
  Is het de bedoeling dat de zin wordt afgemaakt door de display? (Ik zou het dan namelijk uitspreken als "for any compositional pt semantics, compositionality1 has type ...", wat niet precies is wat we willen zeggen.)
- [ ] We gebruiken `statePTR` niet meer, dus de uitleg zou weg kunnen.